### PR TITLE
Use env vars for speech key and add README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 # Project exclude paths
 /target/
+/TraductorVoz/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,15 @@
+# TraductorVoz
+
+Aplicación de ejemplo que utiliza Azure Speech Service para traducir audio en vivo.
+
+## Uso
+
+1. Obtén una clave de Azure Speech y asigna la variable de entorno `AZURE_SPEECH_KEY`.
+2. Opcionalmente define `AZURE_SPEECH_REGION` (por defecto `westeurope`).
+3. Ejecuta la aplicación con Maven:
+
+```bash
+mvn compile exec:java -Dexec.mainClass=traductor.Main
+```
+
+La interfaz muestra subtítulos en inglés del audio reconocido en español.

--- a/src/main/java/traductor/SpeechConfigProvider.java
+++ b/src/main/java/traductor/SpeechConfigProvider.java
@@ -3,16 +3,19 @@ package traductor;
 import com.microsoft.cognitiveservices.speech.translation.SpeechTranslationConfig;
 
 public class SpeechConfigProvider {
-    private static final String SPEECH_KEY = "ClTwLQZs1pBc2bIKgeZLrWaLoUYgERDfgYkSFUd4jRRnlg1wADXUJQQJ99BFAC5RqLJXJ3w3AAAYACOGxHNI"; 
-    private static final String REGION = "westeurope";
+    private static final String DEFAULT_REGION = "westeurope";
 
     public static SpeechTranslationConfig getConfig() {
-        SpeechTranslationConfig config = SpeechTranslationConfig.fromSubscription(SPEECH_KEY, REGION);
+        String key = System.getenv("AZURE_SPEECH_KEY");
+        String region = System.getenv().getOrDefault("AZURE_SPEECH_REGION", DEFAULT_REGION);
+
+        if (key == null || key.trim().isEmpty()) {
+            throw new IllegalStateException("AZURE_SPEECH_KEY environment variable is not set");
+        }
+
+        SpeechTranslationConfig config = SpeechTranslationConfig.fromSubscription(key, region);
         config.setSpeechRecognitionLanguage("es-ES");
         config.addTargetLanguage("en");
         return config;
     }
 }
-
-// Hacer Readme
-//Poner comentarios


### PR DESCRIPTION
## Summary
- secure speech key by reading from env vars
- add usage instructions to README
- ignore temporary project folder

## Testing
- `mvn -q test` *(fails: PluginResolutionException)*
- `mvn -q -DskipTests package` *(fails: PluginResolutionException)*

------
https://chatgpt.com/codex/tasks/task_e_684dfd5b93e8832cbe4e2d776504c4db