### PR TITLE
Add subtitle file output and OBS instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,26 @@
+# TraductorVoz
+
+This project is a small Swing application that uses the Microsoft Speech SDK to translate spoken Spanish into another language in real time. The translated text appears in a translucent window that can stay on top of the screen.
+
+## Subtitle File Output
+
+The application can also write the latest translated text to a file so it can be used by streaming software such as OBS. The location of this file and whether new translations overwrite or append to it can be controlled with system properties:
+
+- `subtitle.file` – path to the text file (default: `subtitles.txt`)
+- `subtitle.append` – set to `true` to append to the file, or `false` to overwrite (default)
+
+Example of running the program and writing subtitles to `/tmp/subs.txt`:
+
+```bash
+java -Dsubtitle.file=/tmp/subs.txt -jar target/TraductorVoz-0.0.1-SNAPSHOT.jar
+```
+
+## Using the Subtitle File in OBS
+
+1. In OBS, add a new **Text (GDI+)** or **Text (FreeType 2)** source.
+2. Enable the **Read from file** option.
+3. Browse and select the subtitle file specified by `subtitle.file`.
+4. Adjust font, size and positioning as desired.
+5. When the application runs, OBS will update the text source automatically with the latest translation.
+
+This allows the translated captions to appear directly in your stream.

--- a/src/main/java/traductor/SubtitleFileWriter.java
+++ b/src/main/java/traductor/SubtitleFileWriter.java
@@ -1,0 +1,58 @@
+package traductor;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
+
+/**
+ * Utility for writing subtitle text to a file so it can be
+ * used by external programs like OBS. The file location and
+ * whether to append or overwrite can be configured using the
+ * system properties:
+ * <ul>
+ *   <li>subtitle.file - path to the text file</li>
+ *   <li>subtitle.append - set to true to append, false to overwrite</li>
+ * </ul>
+ */
+public class SubtitleFileWriter {
+    private final Path filePath;
+    private final boolean append;
+
+    /**
+     * Creates the writer using system properties or defaults.
+     */
+    public SubtitleFileWriter() {
+        this(System.getProperty("subtitle.file", "subtitles.txt"),
+             Boolean.parseBoolean(System.getProperty("subtitle.append", "false")));
+    }
+
+    /**
+     * Creates the writer with the provided configuration.
+     *
+     * @param filePath path to the file
+     * @param append   if true new text will be appended, otherwise the file is overwritten
+     */
+    public SubtitleFileWriter(String filePath, boolean append) {
+        this.filePath = Paths.get(filePath);
+        this.append = append;
+    }
+
+    /**
+     * Writes the given text to the subtitle file.
+     */
+    public void write(String text) {
+        try {
+            if (append) {
+                Files.writeString(filePath, text + System.lineSeparator(),
+                                   StandardOpenOption.CREATE, StandardOpenOption.APPEND);
+            } else {
+                Files.writeString(filePath, text,
+                                   StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING);
+            }
+        } catch (IOException e) {
+            System.err.println("Failed to write subtitle file: " + e.getMessage());
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- allow writing subtitles to file via new `SubtitleFileWriter`
- output displayed text to that file when new translations arrive
- document how to configure and use the subtitle file in OBS

## Testing
- `mvn -q -DskipTests=true package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_684e00963b3c832c986292b657dc7086