### PR TITLE
Add usage instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,26 +1,49 @@
 # TraductorVoz
 
-This project is a small Swing application that uses the Microsoft Speech SDK to translate spoken Spanish into another language in real time. The translated text appears in a translucent window that can stay on top of the screen.
+TraductorVoz is a small Swing application that uses the Microsoft Speech SDK to translate spoken Spanish into your chosen target language. The translation appears in a translucent window that stays on top of the screen and can optionally be saved to a text file.
 
-## Subtitle File Output
+## Prerequisites
 
-The application can also write the latest translated text to a file so it can be used by streaming software such as OBS. The location of this file and whether new translations overwrite or append to it can be controlled with system properties:
+- **Java 11** or later and Maven 3 installed.
+- An **Azure Speech resource** with a subscription key and region.
+- A microphone configured on your system.
+
+Update `SpeechConfigProvider` with your subscription information before running.
+
+## Building and Running
+
+Compile the project using Maven:
+
+```bash
+mvn package
+```
+
+Launch the UI from the generated JAR:
+
+```bash
+java -jar target/TraductorVoz-0.0.1-SNAPSHOT.jar
+```
+
+Use the following properties to control subtitle file output:
 
 - `subtitle.file` – path to the text file (default: `subtitles.txt`)
-- `subtitle.append` – set to `true` to append to the file, or `false` to overwrite (default)
+- `subtitle.append` – set to `true` to append, or `false` to overwrite (default)
 
-Example of running the program and writing subtitles to `/tmp/subs.txt`:
+Example writing subtitles to `/tmp/subs.txt`:
 
 ```bash
 java -Dsubtitle.file=/tmp/subs.txt -jar target/TraductorVoz-0.0.1-SNAPSHOT.jar
 ```
 
-## Using the Subtitle File in OBS
+## Launching the UI
 
-1. In OBS, add a new **Text (GDI+)** or **Text (FreeType 2)** source.
-2. Enable the **Read from file** option.
-3. Browse and select the subtitle file specified by `subtitle.file`.
-4. Adjust font, size and positioning as desired.
-5. When the application runs, OBS will update the text source automatically with the latest translation.
+When the application starts, translation begins asynchronously so that the window appears immediately without blocking the Swing event thread. The `Main` class spawns a `SwingWorker` that calls `startTranslation()` in the background.
 
-This allows the translated captions to appear directly in your stream.
+## Using OBS Studio
+
+You can display the subtitles in OBS in two ways:
+
+1. **Window capture** – add a *Window Capture* source and select the "Subtítulo en Vivo" window. Resize and crop as needed.
+2. **Text from file** – add a *Text* source with *Read from file* enabled and point it to the subtitle file defined by `subtitle.file`.
+
+Either approach lets you overlay the live translation in your stream.


### PR DESCRIPTION
## Summary
- document prerequisites like Java and Azure Speech key
- describe how to run the Maven project and launch the UI
- mention asynchronous translation startup
- explain how to capture the subtitles window or text file in OBS Studio

## Testing
- `mvn -q -DskipTests package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_684e0176c4fc832c83ddc92534f58003