### PR TITLE
Add configurable translation language

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,14 @@ Example writing subtitles to `/tmp/subs.txt`:
 java -Dsubtitle.file=/tmp/subs.txt -jar target/TraductorVoz-0.0.1-SNAPSHOT.jar
 ```
 
+You can change the translation target language by passing it as the first
+command‑line argument or via the `target.language` system property. The default
+target language is `en` (English). For example, to translate into French:
+
+```bash
+java -Dtarget.language=fr -jar target/TraductorVoz-0.0.1-SNAPSHOT.jar
+```
+
 ## Launching the UI
 
 When the application starts, translation begins asynchronously so that the window appears immediately without blocking the Swing event thread. The `Main` class spawns a `SwingWorker` that calls `startTranslation()` in the background.

--- a/src/main/java/traductor/Main.java
+++ b/src/main/java/traductor/Main.java
@@ -7,8 +7,19 @@ public class Main {
     public static void main(String[] args) {
         String targetLanguage = "en";
 
+        if (args.length > 0 && args[0] != null && !args[0].trim().isEmpty()) {
+            targetLanguage = args[0].trim();
+        } else {
+            String prop = System.getProperty("target.language");
+            if (prop != null && !prop.trim().isEmpty()) {
+                targetLanguage = prop.trim();
+            }
+        }
+
+        final String lang = targetLanguage;
+
         SwingUtilities.invokeLater(() -> {
-            SpeechTranslatorService translatorService = new SpeechTranslatorService(targetLanguage);
+            SpeechTranslatorService translatorService = new SpeechTranslatorService(lang);
             TranslatorAppView view = new TranslatorAppView(translatorService);
             view.setVisible(true);
 

--- a/src/main/java/traductor/SpeechConfigProvider.java
+++ b/src/main/java/traductor/SpeechConfigProvider.java
@@ -6,7 +6,7 @@ public class SpeechConfigProvider {
     private static final String KEY_ENV_VAR = "AZURE_SPEECH_KEY";
     private static final String REGION_ENV_VAR = "AZURE_SPEECH_REGION";
 
-    public static SpeechTranslationConfig getConfig() {
+    public static SpeechTranslationConfig getConfig(String targetLanguage) {
         String key = System.getenv(KEY_ENV_VAR);
         if (key == null || key.isEmpty()) {
             throw new IllegalStateException("Environment variable " + KEY_ENV_VAR + " is not set");
@@ -19,7 +19,7 @@ public class SpeechConfigProvider {
 
         SpeechTranslationConfig config = SpeechTranslationConfig.fromSubscription(key, region);
         config.setSpeechRecognitionLanguage("es-ES");
-        config.addTargetLanguage("en");
+        config.addTargetLanguage(targetLanguage);
         return config;
     }
 }

--- a/src/main/java/traductor/SpeechTranslatorService.java
+++ b/src/main/java/traductor/SpeechTranslatorService.java
@@ -20,7 +20,7 @@ public class SpeechTranslatorService {
      
 
         try {
-            SpeechTranslationConfig config = SpeechConfigProvider.getConfig();
+            SpeechTranslationConfig config = SpeechConfigProvider.getConfig(targetLanguage);
             recognizer = new TranslationRecognizer(config);
 
             recognizer.recognized.addEventListener((s, e) -> {


### PR DESCRIPTION
## Summary
- allow the target language to be defined via the first command-line argument or `target.language` system property
- wire the target language through the speech config
- document the new option in the README

## Testing
- `mvn -q -DskipTests package` *(fails: Could not transfer artifact maven-resources-plugin due to network issues)*

------
https://chatgpt.com/codex/tasks/task_e_684e04fe9b58832c90a7927e10b60e2d