### PR TITLE
Add Java 11 compiler plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,4 +22,17 @@
       <url>https://azureai.azureedge.net/maven/</url>
     </repository>
   </repositories>
+
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.10.1</version>
+        <configuration>
+          <source>11</source>
+          <target>11</target>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>


### PR DESCRIPTION
## Summary
- configure Maven compiler plugin to use Java 11
- confirm README already documents Java 11 requirement

## Testing
- `mvn -q -DskipTests package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_684e0c3b6394832cb10d522d36b6fd6f