### PR TITLE
Use java.util.logging and replace println

### DIFF
--- a/src/main/java/traductor/SpeechTranslatorService.java
+++ b/src/main/java/traductor/SpeechTranslatorService.java
@@ -2,8 +2,11 @@ package traductor;
 
 import com.microsoft.cognitiveservices.speech.*;
 import com.microsoft.cognitiveservices.speech.translation.*;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 public class SpeechTranslatorService {
+    private static final Logger LOGGER = Logger.getLogger(SpeechTranslatorService.class.getName());
     private TranslationRecognizer recognizer;
     private TranslationListener listener;
     private final String targetLanguage;
@@ -28,8 +31,9 @@ public class SpeechTranslatorService {
              
                     String original = e.getResult().getText();
                     String translated = e.getResult().getTranslations().get(targetLanguage);
-                   	System.out.println(translated);
-                   	System.out.println();
+                    if (translated != null) {
+                        LOGGER.info(translated);
+                    }
                     if (translated != null && !translated.trim().isEmpty()) {
                         listener.onFinalResult(original, translated);
                     }
@@ -38,22 +42,23 @@ public class SpeechTranslatorService {
 
             recognizer.canceled.addEventListener((s, e) -> {
                 String details = e.getErrorDetails();
-                System.out.println("Error: " + details);
+                LOGGER.log(Level.SEVERE, "Error: {0}", details);
                 if (listener != null) listener.onError(details);
 
              
             });
 
             recognizer.sessionStopped.addEventListener((s, e) -> {
-            	System.out.println("Sesion terminada");
+                LOGGER.info("Session ended");
                 if (listener != null) listener.onSessionStopped();
             });
 
             recognizer.startContinuousRecognitionAsync().get();
 
         } catch (Exception e) {
+            LOGGER.log(Level.SEVERE, "Failed to start translation", e);
             if (listener != null) listener.onError(e.getMessage());
-         
+
         }
     }
 
@@ -65,6 +70,7 @@ public class SpeechTranslatorService {
                 recognizer = null;
             }
         } catch (Exception e) {
+            LOGGER.log(Level.SEVERE, "Failed to stop translation", e);
             if (listener != null) listener.onError(e.getMessage());
         }
     }

--- a/src/main/java/traductor/SubtitleFileWriter.java
+++ b/src/main/java/traductor/SubtitleFileWriter.java
@@ -5,6 +5,8 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * Utility for writing subtitle text to a file so it can be
@@ -17,6 +19,7 @@ import java.nio.file.StandardOpenOption;
  * </ul>
  */
 public class SubtitleFileWriter {
+    private static final Logger LOGGER = Logger.getLogger(SubtitleFileWriter.class.getName());
     private final Path filePath;
     private final boolean append;
 
@@ -52,7 +55,7 @@ public class SubtitleFileWriter {
                                    StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING);
             }
         } catch (IOException e) {
-            System.err.println("Failed to write subtitle file: " + e.getMessage());
+            LOGGER.log(Level.SEVERE, "Failed to write subtitle file", e);
         }
     }
 }


### PR DESCRIPTION
## Summary
- integrate java.util.logging framework
- replace System.out/err.println with log statements
- use English log messages

## Testing
- `mvn -q -DskipTests=false package` *(fails: Plugin could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_684e0d268f34832cb94cba2c7a8d93fd