### PR TITLE
Add setup script for API credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ export AZURE_SPEECH_KEY=<your-key>
 export AZURE_SPEECH_REGION=<your-region>
 ```
 
+Alternatively you can use the `run.sh` script provided in this repository. It
+will ask for the key and region the first time you run it and then launch the
+application with those values set.
+
 `SpeechConfigProvider` reads these variables when creating the SDK configuration.
 
 ## Building and Running
@@ -25,6 +29,14 @@ Compile the project using Maven:
 ```bash
 mvn package
 ```
+
+Run the application using the helper script which will prompt for your
+credentials if they are not already set:
+
+```bash
+./run.sh
+```
+
 
 ## Running Tests
 

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# Prompt for API key and region if not set in environment
+if [ -z "$AZURE_SPEECH_KEY" ]; then
+  read -p "Azure Speech Key: " AZURE_SPEECH_KEY
+fi
+if [ -z "$AZURE_SPEECH_REGION" ]; then
+  read -p "Azure Speech Region: " AZURE_SPEECH_REGION
+fi
+
+export AZURE_SPEECH_KEY
+export AZURE_SPEECH_REGION
+
+# Build the project if the JAR doesn't exist
+if [ ! -f target/TraductorVoz-0.0.1-SNAPSHOT.jar ]; then
+  mvn package || { echo "Build failed"; exit 1; }
+fi
+
+# Run the application, forwarding any extra args (e.g., target language)
+java -jar target/TraductorVoz-0.0.1-SNAPSHOT.jar "$@"


### PR DESCRIPTION
## Summary
- add `run.sh` for interactive setup of Azure credentials and running the app
- document the new script in README

## Testing
- `mvn -q test` *(fails: Could not transfer artifact)*

------
https://chatgpt.com/codex/tasks/task_e_684e13d53360832cbb9c76fad87490a6