### PR TITLE
Add persistent config file for run.sh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 # Project exclude paths
 /target
 TraductorVoz/
+# Credentials stored by run.sh
+.traductor.env
 # IDE and editor files
 .idea/
 .classpath

--- a/README.md
+++ b/README.md
@@ -17,8 +17,9 @@ export AZURE_SPEECH_REGION=<your-region>
 ```
 
 Alternatively you can use the `run.sh` script provided in this repository. It
-will ask for the key and region the first time you run it and then launch the
-application with those values set.
+prompts for the key and region the first time and stores them in `.traductor.env`
+so subsequent runs reuse the saved values. Delete or edit this file if your
+credentials change.
 
 `SpeechConfigProvider` reads these variables when creating the SDK configuration.
 
@@ -30,8 +31,8 @@ Compile the project using Maven:
 mvn package
 ```
 
-Run the application using the helper script which will prompt for your
-credentials if they are not already set:
+Run the application using the helper script which stores your credentials in
+`.traductor.env` the first time you run it:
 
 ```bash
 ./run.sh

--- a/run.sh
+++ b/run.sh
@@ -1,11 +1,22 @@
 #!/bin/bash
 
+# Configuration file used to persist credentials
+CONFIG_FILE=".traductor.env"
+
+# Load stored variables if present
+if [ -f "$CONFIG_FILE" ]; then
+  # shellcheck source=/dev/null
+  . "$CONFIG_FILE"
+fi
+
 # Prompt for API key and region if not set in environment
 if [ -z "$AZURE_SPEECH_KEY" ]; then
   read -p "Azure Speech Key: " AZURE_SPEECH_KEY
+  echo "AZURE_SPEECH_KEY=\"$AZURE_SPEECH_KEY\"" >> "$CONFIG_FILE"
 fi
 if [ -z "$AZURE_SPEECH_REGION" ]; then
   read -p "Azure Speech Region: " AZURE_SPEECH_REGION
+  echo "AZURE_SPEECH_REGION=\"$AZURE_SPEECH_REGION\"" >> "$CONFIG_FILE"
 fi
 
 export AZURE_SPEECH_KEY


### PR DESCRIPTION
## Summary
- keep run credentials between runs in `.traductor.env`
- ignore `.traductor.env` so credentials aren't committed
- document new behaviour in README

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e942b79d8832cb3f57412242d1ede