### PR TITLE
Handle window closure in TranslatorAppView

### DIFF
--- a/src/main/java/traductor/TranslatorAppView.java
+++ b/src/main/java/traductor/TranslatorAppView.java
@@ -2,6 +2,8 @@ package traductor;
 
 import javax.swing.*;
 import java.awt.*;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
 import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
@@ -62,7 +64,15 @@ public class TranslatorAppView extends JFrame implements TranslationListener {
 
                 setContentPane(bgPanel);
                 getRootPane().setOpaque(false);
-	}
+
+                setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+                addWindowListener(new WindowAdapter() {
+                        @Override
+                        public void windowClosing(WindowEvent e) {
+                                translatorService.stopTranslation();
+                        }
+                });
+        }
 
 	private void restartClearTimer() {
 		if (clearTimer != null && clearTimer.isRunning())

--- a/src/test/java/traductor/SubtitleFileWriterTest.java
+++ b/src/test/java/traductor/SubtitleFileWriterTest.java
@@ -1,3 +1,5 @@
+package traductor;
+
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.nio.file.Files;


### PR DESCRIPTION
## Summary
- close TranslatorAppView when exiting
- stop ongoing translation when the window closes
- fix SubtitleFileWriterTest package declaration

## Testing
- `mvn -q test` *(fails: SubtitleFileWriterTest.disablesWritingWhenPathNotWritable)*

------
https://chatgpt.com/codex/tasks/task_e_684ea6f93430832c94d986dfdd405794