### PR TITLE
Fix run.sh console closing issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,11 @@ Run the application using the helper script which stores your credentials in
 ./run.sh
 ```
 
+If you run the script from a file explorer on Windows, a new console window may
+open and close immediately after execution, hiding any errors. Instead, open a
+terminal (for example *Git Bash*) and launch `./run.sh` from there so the
+output remains visible.
+
 
 ## Running Tests
 

--- a/run.sh
+++ b/run.sh
@@ -31,3 +31,7 @@ mvn -q exec:java -Dexec.mainClass=traductor.Main -Dexec.args="$*" || {
   echo "Application failed";
   exit 1;
 }
+
+# Keep the window open so any error messages remain visible when
+# the script is launched from a graphical shell.
+read -p "Presiona Enter para salir" _


### PR DESCRIPTION
## Summary
- keep the console window open after running `run.sh`
- clarify in README how to run `run.sh` from a terminal

## Testing
- `mvn -q test`

------
https://chatgpt.com/codex/tasks/task_e_684ebbb05244832ca6fc102359e70f3f